### PR TITLE
Fix heading typo

### DIFF
--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -34,7 +34,7 @@ export default function Login() {
   return (
   <div className="h-screen w-full bg-[#EDF2F7] flex items-center justify-center p-0 font-sans">
       <div className="w-full max-w-3xl bg-white p-8 rounded-lg shadow-md font-sans">
-        <h1 className="text-3xl font-semiblod text-center text-[#00bcd4] mb-2">
+        <h1 className="text-3xl font-semibold text-center text-[#00bcd4] mb-2">
           Zaloguj się
         </h1>
         <p className="text-center text-base leading-relaxed text-gray-600 mb-8">


### PR DESCRIPTION
## Summary
- fix misspelled font weight in auth login page

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684566b749f4832789228bd930a7ff2c